### PR TITLE
eip1559: add requirements.txt

### DIFF
--- a/eip1559/requirements.txt
+++ b/eip1559/requirements.txt
@@ -1,0 +1,3 @@
+cadCAD
+jupyter
+seaborn


### PR DESCRIPTION
Only tried running `eip1559.ipynb`. Other files may have other reqs.

JIC, running in a `virtualenv` requires [setting up a custom Jupyter kernel](https://stackoverflow.com/a/46312117/7056908).

-----

FTR, at the time of submission, the package versions were:

```
cadCAD==0.3.1
jupyter==1.0.0
seaborn==0.10.1
```